### PR TITLE
Reduce nginx's DNS resolver cache to almost nothing

### DIFF
--- a/docker/web-proxy/nginx/conf.d/home.conf
+++ b/docker/web-proxy/nginx/conf.d/home.conf
@@ -1,4 +1,5 @@
-resolver 127.0.0.11;
+resolver 127.0.0.11 valid=1s;
+resolver_timeout 2s;
 
 map $subdomain $dest_port {
     default 80;


### PR DESCRIPTION
Buoy is for development only, so the DNS cache can be safely super short
and allows for a better experience (if the upstream's IP changes, we
only need to wait one second for the cache to clear).