### PR TITLE
Allow any domain to be used with buoy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,18 +6,20 @@ services:
     volumes:
       - ./data/ssl/certs:/cert
     environment:
-      - DOMAIN
+      DOMAIN: ${DOMAIN:-b.com}
 
   buoy:
-    image: nginx:1.13.12-alpine
-    restart: always
+    image: kelvineducation/nginx-envsubst:0.2.1
+    restart: unless-stopped
     volumes:
       - ./data/ssl/certs:/etc/ssl/certs
-      - ./docker/web-proxy/nginx/conf.d:/etc/nginx/conf.d
+      - ./docker/web-proxy/nginx/conf.d/home.conf:/etc/nginx/conf.d/home.conf.envsubst
       - ./:/etc/nginx/map.d
     ports:
       - "80:80"
       - "443:443"
+    environment:
+      DOMAIN: ${DOMAIN:-b.com}
 
 networks:
   default:

--- a/docker/web-proxy/nginx/conf.d/home.conf
+++ b/docker/web-proxy/nginx/conf.d/home.conf
@@ -22,7 +22,7 @@ server {
 server {
     listen      80;
     listen      443 ssl;
-    server_name ~([^\.]+?).[a-z].com$;
+    server_name ~([^\.]+?).${DOMAIN}$;
     set $subdomain $1;
 
     set $dest_scheme $scheme;


### PR DESCRIPTION
Previously Buoy only supported single letter `.com` domains.