### PR TITLE
Allow subdomains to be mapped explicitly to destination address

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,15 @@ docker-compose restart buoy
 ```
 
 The service will be accessed from a web browser through the implicit port 80 or 443, for HTTP and HTTPS respectively, but Buoy will now know to connect to your service on the port you identified in the subdomain-port map file.
+
+### Setting destination service address
+
+Some web services are ran outside of Docker.  In those cases, you can explicitly map a Buoy subdomain to a destination address by creating a `subdomain-addr.local.map` file in the `buoy` root directory and mapping subdomains to ports like so:
+```nginx
+"host"     172.17.0.1;
+```
+
+You will need to restart buoy after making subdomain-addr mapping changes:
+```bash
+docker-compose restart buoy
+```

--- a/docker/web-proxy/nginx/conf.d/home.conf
+++ b/docker/web-proxy/nginx/conf.d/home.conf
@@ -7,6 +7,12 @@ map $subdomain $dest_port {
     include "/etc/nginx/map.d/subdomain-port.*.map";
 }
 
+map $subdomain $dest_addr {
+    default $subdomain;
+
+    include "/etc/nginx/map.d/subdomain-addr.*.map";
+}
+
 map $http_upgrade $connection_upgrade {
     default upgrade;
     '' close;
@@ -39,7 +45,7 @@ server {
     ssl_certificate_key /etc/ssl/certs/dev.key;
 
     location / {
-        proxy_pass                 $dest_scheme://$subdomain:$dest_port;
+        proxy_pass                 $dest_scheme://$dest_addr:$dest_port;
         proxy_redirect             ~^http(?:s)?://([^:]+):[0-9]+(/.+)?$ $scheme://$1$2;
         proxy_ssl_verify           off;
         proxy_set_header           Host $host;


### PR DESCRIPTION
This feature is useful for allowing a Buoy domain to refer to a web service outside of Docker.